### PR TITLE
feat: RaceCancellation PromiseLike support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ node_js:
   - "stable"
 after_script:
   - "cat ./coverage/lcov.info | yarn coveralls"
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+\.\d+/

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -36,7 +36,7 @@ export interface Cancellation<Kind extends string = string> {
 export type Complete<Result> = (result: Result) => void;
 
 export type RaceCancellation = <Result>(
-  task: Task<Result>
+  task: Task<Result> | PromiseLike<Result>
 ) => Promise<Result | Cancellation>;
 
 export type NewCancellation = () => Cancellation;

--- a/src/newRaceCancellation.ts
+++ b/src/newRaceCancellation.ts
@@ -25,12 +25,14 @@ export default function newRaceCancellation(
 
 function raceCancellation<Result>(
   cancellation: Oneshot<unknown>,
-  task: Task<Result>,
+  task: Task<Result> | PromiseLike<Result>,
   intoCancellation: IntoCancellation
 ): Promise<Result | Cancellation> {
-  return cancellation[hasCompleted]
-    ? cancellation().then(intoCancellation)
-    : Promise.race([task(), cancellation().then(intoCancellation)]);
+  return typeof task === "function"
+    ? cancellation[hasCompleted]
+      ? cancellation().then(intoCancellation)
+      : Promise.race([task(), cancellation().then(intoCancellation)])
+    : Promise.race([task, cancellation().then(intoCancellation)]);
 }
 
 function newIntoCancellation(

--- a/src/noopRaceCancellation.ts
+++ b/src/noopRaceCancellation.ts
@@ -5,7 +5,10 @@ import { RaceCancellation, Task } from "./interfaces";
  * in a backwards compatible way by using this as the default.
  */
 const noopRaceCancellation: RaceCancellation = <Result>(
-  task: Task<Result>
-): Promise<Result> => Promise.resolve().then(task);
+  task: Task<Result> | PromiseLike<Result>
+): Promise<Result> =>
+  typeof task === "function"
+    ? Promise.resolve().then(task)
+    : Promise.resolve(task);
 
 export default noopRaceCancellation;

--- a/tests/cancellableRaceTest.js
+++ b/tests/cancellableRaceTest.js
@@ -1,0 +1,18 @@
+const { cancellableRace } = require("race-cancellation");
+
+QUnit.module("cancellableRace", () => {
+  QUnit.test("cancel before race already rejected promise", async assert => {
+    assert.expect(1);
+
+    const [raceCancellation, cancel] = cancellableRace();
+
+    cancel();
+    const task = Promise.reject(new Error("failed task"));
+
+    try {
+      await raceCancellation(task);
+    } catch (e) {
+      assert.equal(e.message, "failed task");
+    }
+  });
+});

--- a/tests/combineRaceCancellationTest.js
+++ b/tests/combineRaceCancellationTest.js
@@ -2,6 +2,7 @@ const {
   combineRaceCancellation,
   cancellableRace,
   throwIfCancelled,
+  noopRaceCancellation,
 } = require("race-cancellation");
 
 QUnit.module("combineRaceCancellation", () => {
@@ -14,7 +15,7 @@ QUnit.module("combineRaceCancellation", () => {
 
   QUnit.test("calling combine with b as undefined", async assert => {
     const raceCancellation = combineRaceCancellation(
-      task => Promise.resolve().then(task),
+      noopRaceCancellation,
       undefined
     );
     const expected = new Date();
@@ -23,8 +24,9 @@ QUnit.module("combineRaceCancellation", () => {
   });
 
   QUnit.test("calling combine with a as undefined", async assert => {
-    const raceCancellation = combineRaceCancellation(undefined, task =>
-      Promise.resolve().then(task)
+    const raceCancellation = combineRaceCancellation(
+      undefined,
+      noopRaceCancellation
     );
     const expected = new Date();
     const actual = await raceCancellation(() => Promise.resolve(expected));

--- a/tests/noopRaceCancellationTest.js
+++ b/tests/noopRaceCancellationTest.js
@@ -6,4 +6,10 @@ QUnit.module("noopRaceCancellation", () => {
     const actual = await noopRaceCancellation(() => Promise.resolve(expected));
     assert.equal(actual, expected);
   });
+
+  QUnit.test("it just resolves the promise", async assert => {
+    const expected = new Date();
+    const actual = await noopRaceCancellation(Promise.resolve(expected));
+    assert.equal(actual, expected);
+  });
 });


### PR DESCRIPTION
Last update I removed the ability to pass in an existing promise to RaceCancellation and this adds it back.

The assumption of this library is you don't create promises you are not ready to make part of the current chain. So this was removed to simplify code but the concept of not making promises before you place them into the chain seems like a tough hurdle for people to understand.

When people close over a promise to do `await raceCancellation(() => promise)` when it is already in the cancelled state, it will not invoke the passed in task and create the `Promise.race` which is a feature of this library. The issue with this behavior, is if the promise isn't created by the task but closed over, it has the potential to trigger an unhandled promise rejection in this scenario.

This change will always create the race regardless of the cancellation state if you pass in a promise like instead of a function which allows you to opt out of the short circuiting.
